### PR TITLE
more reliable Connection to AP

### DIFF
--- a/src/ESP8266MQTTMesh.cpp
+++ b/src/ESP8266MQTTMesh.cpp
@@ -394,7 +394,9 @@ void ESP8266MQTTMesh::scan() {
                 }
             } else {
                 //AP is mesh node
-                if (ap_ptr->ssid_idx != NETWORK_MESH_NODE || rssi <= ap_ptr->rssi) {
+                if (
+                  ((ap_ptr->ssid_idx != NETWORK_MESH_NODE) && ap_ptr->rssi <= -75) ||
+                  rssi <= ap_ptr->rssi) {
                    continue;
                 }
             }


### PR DESCRIPTION
if the Node scans the Networks and finds an Acess Point with a bad connection it now prefers to connect to a nother Node instead of to the AP.